### PR TITLE
add report for services

### DIFF
--- a/sql/tunas360_2h_top_services.sql
+++ b/sql/tunas360_2h_top_services.sql
@@ -1,0 +1,92 @@
+DEF section_id = '2h';
+DEF section_name = 'Top Services';
+EXEC DBMS_APPLICATION_INFO.SET_MODULE('&&tunas360_prefix.','&&section_id.');
+SPO &&tunas360_main_report..html APP;
+PRO <h2>&&section_id.. &&section_name.</h2>
+PRO <ol start="&&report_sequence.">
+SPO OFF;
+
+DEF main_table = 'GV$SESSION';
+BEGIN
+  :sql_text_backup := '
+SELECT service_name,
+       samples,
+       TRUNC(100*RATIO_TO_REPORT(samples) OVER (),2) percent,
+       NULL dummy_01
+  FROM (SELECT service_name,
+               COUNT(*) samples
+         FROM (SELECT position inst_id, object_alias service_name 
+                 FROM plan_table
+                WHERE statement_id = ''TUNAS360_DATA'')
+        WHERE @filter_predicate@
+        GROUP BY service_name)
+ ORDER BY 2 DESC NULLS LAST
+';
+END;
+/
+
+DEF skip_pch = '';
+DEF skip_all = '&&is_single_instance.';
+DEF title = 'Top Services for Cluster';
+EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', '1 = 1 /* all instances */');
+@@&&skip_all.tunas360_9a_pre_one.sql
+
+DEF skip_pch = '';
+DEF skip_all = 'Y';
+SELECT NULL skip_all FROM gv$instance WHERE inst_id = 1;
+DEF title = 'Top Services for Instance 1';
+EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'inst_id = 1');
+@@&&skip_all.tunas360_9a_pre_one.sql
+
+DEF skip_pch = '';
+DEF skip_all = 'Y';
+SELECT NULL skip_all FROM gv$instance WHERE inst_id = 2;
+DEF title = 'Top Services for Instance 2';
+EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'inst_id = 2');
+@@&&skip_all.tunas360_9a_pre_one.sql
+
+DEF skip_pch = '';
+DEF skip_all = 'Y';
+SELECT NULL skip_all FROM gv$instance WHERE inst_id = 3;
+DEF title = 'Top Services for Instance 3';
+EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'inst_id = 3');
+@@&&skip_all.tunas360_9a_pre_one.sql
+
+DEF skip_pch = '';
+DEF skip_all = 'Y';
+SELECT NULL skip_all FROM gv$instance WHERE inst_id = 4;
+DEF title = 'Top Services for Instance 4';
+EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'inst_id = 4');
+@@&&skip_all.tunas360_9a_pre_one.sql
+
+DEF skip_pch = '';
+DEF skip_all = 'Y';
+SELECT NULL skip_all FROM gv$instance WHERE inst_id = 5;
+DEF title = 'Top Services for Instance 5';
+EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'inst_id = 5');
+@@&&skip_all.tunas360_9a_pre_one.sql
+
+DEF skip_pch = '';
+DEF skip_all = 'Y';
+SELECT NULL skip_all FROM gv$instance WHERE inst_id = 6;
+DEF title = 'Top Services for Instance 6';
+EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'inst_id = 6');
+@@&&skip_all.tunas360_9a_pre_one.sql
+
+DEF skip_pch = '';
+DEF skip_all = 'Y';
+SELECT NULL skip_all FROM gv$instance WHERE inst_id = 7;
+DEF title = 'Top Services for Instance 7';
+EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'inst_id = 7');
+@@&&skip_all.tunas360_9a_pre_one.sql
+
+DEF skip_pch = '';
+DEF skip_all = 'Y';
+SELECT NULL skip_all FROM gv$instance WHERE inst_id = 8;
+DEF title = 'Top Services for Instance 8';
+EXEC :sql_text := REPLACE(:sql_text_backup, '@filter_predicate@', 'inst_id = 8');
+@@&&skip_all.tunas360_9a_pre_one.sql
+
+SPO &&tunas360_main_report..html APP;
+PRO </ol>
+SPO OFF;

--- a/sql/tunas360_main.sql
+++ b/sql/tunas360_main.sql
@@ -38,6 +38,7 @@ PRO </td><td>
 @@tunas360_2e_top_programs.sql
 @@tunas360_2f_top_modules.sql
 @@tunas360_2g_top_objects.sql
+@@tunas360_2h_top_services.sql
 
 PRO
 SPO OFF;


### PR DESCRIPTION
In addition to user/module etc I wanted a report on services. Not only can this be useful if you are explicitly using services but also with 12c multitenant to show AAS per pdb.

The change was mostly a straight forward copy of the modules script, I only had to add a join to the sql that inserts from ASH (if licensed) as active_session_history only has the service_hash, not the name.

Let me know what you think.

cheers
Bjoerm
